### PR TITLE
Feature/cv-627/game_frame_package

### DIFF
--- a/churaverse-engine-client/src/eventbus/IEventBus.ts
+++ b/churaverse-engine-client/src/eventbus/IEventBus.ts
@@ -21,6 +21,15 @@ export interface IEventBus<Scene extends Scenes> {
   ) => void
 
   /**
+   * イベントがpostされた時に実行されるlistener(callback)を解除する.
+   * @param type イベント名
+   * @param listener typeで指定したイベントがpostされた時に実行される関数
+   */
+  unsubscribeEvent: <EvType extends CVEventType<Scene> & string>(
+    type: EvType,
+    listener: CVEventListener<CVEventMap<Scene>[EvType]>
+  ) => void
+  /**
    * イベントを発火する. subscribeEventで登録したlistenerが実行される.
    * @param event 発火するイベント
    */

--- a/churaverse-engine-client/src/eventbus/IEventBus.ts
+++ b/churaverse-engine-client/src/eventbus/IEventBus.ts
@@ -29,6 +29,7 @@ export interface IEventBus<Scene extends Scenes> {
     type: EvType,
     listener: CVEventListener<CVEventMap<Scene>[EvType]>
   ) => void
+
   /**
    * イベントを発火する. subscribeEventで登録したlistenerが実行される.
    * @param event 発火するイベント

--- a/churaverse-engine-client/src/eventbus/eventBus.ts
+++ b/churaverse-engine-client/src/eventbus/eventBus.ts
@@ -17,6 +17,14 @@ export class EventBus<Scene extends Scenes> implements IEventBus<Scene> {
     listenerList.register(priority, listener)
   }
 
+  public unsubscribeEvent<EvType extends CVEventType<Scene> & string>(
+    type: EvType,
+    listener: CVEventListener<CVEventMap<Scene>[EvType]>
+  ): void {
+    const listenerList = this.eventListenerHelper.getListenerList<EvType>(type)
+    listenerList.unregister(listener)
+  }
+
   public post(event: CVEventMap<Scene>[string]): void {
     for (const listener of this.getListeners(event.type)) {
       if (event.isCanceled) break

--- a/churaverse-engine-client/src/store/store.ts
+++ b/churaverse-engine-client/src/store/store.ts
@@ -35,11 +35,11 @@ export class Store<Scene extends Scenes> {
   }
 
   /**
-   * 指定したstoreをリセットする
+   * 指定したstoreを削除する
    * リセットされたstoreの値はundefinedになる
    * @param storeName リセットしたいstoreの名前
    */
-  public reset<Key extends keyof StoreIn<Scene>>(storeName: Key): void {
+  public deleteStoreOf<Key extends keyof StoreIn<Scene>>(storeName: Key): void {
     this.shared[storeName] = undefined
   }
 

--- a/churaverse-engine-client/src/store/store.ts
+++ b/churaverse-engine-client/src/store/store.ts
@@ -36,8 +36,8 @@ export class Store<Scene extends Scenes> {
 
   /**
    * 指定したstoreを削除する
-   * リセットされたstoreの値はundefinedになる
-   * @param storeName リセットしたいstoreの名前
+   * 削除されたstoreの値はundefinedになる
+   * @param storeName 削除したいstoreの名前
    */
   public deleteStoreOf<Key extends keyof StoreIn<Scene>>(storeName: Key): void {
     this.shared[storeName] = undefined

--- a/churaverse-engine-client/src/store/store.ts
+++ b/churaverse-engine-client/src/store/store.ts
@@ -34,6 +34,15 @@ export class Store<Scene extends Scenes> {
     return store
   }
 
+  /**
+   * 指定したstoreをリセットする
+   * リセットされたstoreの値はundefinedになる
+   * @param storeName リセットしたいstoreの名前
+   */
+  public reset<Key extends keyof StoreIn<Scene>>(storeName: Key): void {
+    this.shared[storeName] = undefined
+  }
+
   public deleteStore(): void {
     this.shared = {}
   }
@@ -51,5 +60,5 @@ export interface StoreInMain {
 export type StoreIn<Scene extends Scenes> = Scene extends ITitleScene
   ? StoreInTitle
   : Scene extends IMainScene
-  ? StoreInMain
-  : never
+    ? StoreInMain
+    : never

--- a/churaverse-engine-server/src/eventbus/IEventBus.ts
+++ b/churaverse-engine-server/src/eventbus/IEventBus.ts
@@ -23,7 +23,7 @@ export interface IEventBus<Scene extends Scenes> {
   /**
    * イベントがpostされた時に実行されるlistener(callback)を削除する.
    * @param type イベント名
-   * @param listener 削除するlistener
+   * @param listener typeで指定したイベントがpostされた時に実行される関数
    */
   unsubscribeEvent: <EvType extends CVEventType<Scene>>(
     type: EvType,

--- a/churaverse-engine-server/src/eventbus/IEventBus.ts
+++ b/churaverse-engine-server/src/eventbus/IEventBus.ts
@@ -21,6 +21,16 @@ export interface IEventBus<Scene extends Scenes> {
   ) => void
 
   /**
+   * イベントがpostされた時に実行されるlistener(callback)を削除する.
+   * @param type イベント名
+   * @param listener 削除するlistener
+   */
+  unsubscribeEvent: <EvType extends CVEventType<Scene>>(
+    type: EvType,
+    listener: CVEventListener<CVEventMap<Scene>[EvType]>
+  ) => void
+
+  /**
    * イベントを発火する. subscribeEventで登録したlistenerが実行される.
    * @param event 発火するイベント
    */

--- a/churaverse-engine-server/src/eventbus/eventBus.ts
+++ b/churaverse-engine-server/src/eventbus/eventBus.ts
@@ -17,6 +17,14 @@ export class EventBus<Scene extends Scenes> implements IEventBus<Scene> {
     listenerList.register(priority, listener)
   }
 
+  public unsubscribeEvent<EvType extends CVEventType<Scene>>(
+    type: EvType,
+    listener: CVEventListener<CVEventMap<Scene>[EvType]>
+  ): void {
+    const listenerList = this.eventListenerHelper.getListenerList<EvType>(type)
+    listenerList.unregister(listener)
+  }
+
   public post(event: CVEventMap<Scene>[string]): void {
     for (const listener of this.getListeners(event.type)) {
       if (event.isCanceled) break

--- a/churaverse-engine-server/src/store/store.ts
+++ b/churaverse-engine-server/src/store/store.ts
@@ -36,11 +36,11 @@ export class Store<Scene extends Scenes> {
   }
 
   /**
-   * 指定したstoreをリセットする
+   * 指定したstoreを削除する
    * リセットされたstoreの値はundefinedになる
    * @param storeName リセットしたいstoreの名前
    */
-  public reset<Key extends keyof StoreIn<Scene>>(storeName: Key): void {
+  public deleteStoreOf<Key extends keyof StoreIn<Scene>>(storeName: Key): void {
     this.shared[storeName] = undefined
   }
 

--- a/churaverse-engine-server/src/store/store.ts
+++ b/churaverse-engine-server/src/store/store.ts
@@ -35,6 +35,15 @@ export class Store<Scene extends Scenes> {
     return store
   }
 
+  /**
+   * 指定したstoreをリセットする
+   * リセットされたstoreの値はundefinedになる
+   * @param storeName リセットしたいstoreの名前
+   */
+  public reset<Key extends keyof StoreIn<Scene>>(storeName: Key): void {
+    this.shared[storeName] = undefined
+  }
+
   public deleteStore(): void {
     this.shared = {}
   }

--- a/churaverse-engine-server/src/store/store.ts
+++ b/churaverse-engine-server/src/store/store.ts
@@ -37,8 +37,8 @@ export class Store<Scene extends Scenes> {
 
   /**
    * 指定したstoreを削除する
-   * リセットされたstoreの値はundefinedになる
-   * @param storeName リセットしたいstoreの名前
+   * 削除されたstoreの値はundefinedになる
+   * @param storeName 削除したいstoreの名前
    */
   public deleteStoreOf<Key extends keyof StoreIn<Scene>>(storeName: Key): void {
     this.shared[storeName] = undefined


### PR DESCRIPTION
# 概要
https://churadata.backlog.com/view/CV-627

## 変更内容

- ゲームフレームワークの作成の際に、不要なイベント・ストアを削除できるようにするため、churaverse-engine部分に削除することができる関数を作成しました。

## 補足
- churaverse-pluginsのPRのリンク：https://github.com/churadata/churaverse-plugins/pull/2
- churaverse-privateのブランチ名は、`feature/CV-627/npm_game_frame_package`になっております

## チェックリスト
- [x] 最新の master ブランチを作業ブランチに取り込んでいますか？
- [x] 最後に Push したその状態は動作確認をしていますか？
- [x] File changed は確認しましたか？
  - print デバッグなどで使用した print 文や log 出力は消しましたか？
  - 不必要なメモや使わなくなったコード残していないですか？
  - 意図していない変更や修正が含まれていないですか？
  - 第三者が見てよくわからない命名などになっていませんか？
- [x] マージできる状態になっていますか？
  - コンフリクトは起きていないですか？