### PR TITLE
readonlyを外すユーティリティ型の作成

### DIFF
--- a/churaverse-engine-client/src/index.ts
+++ b/churaverse-engine-client/src/index.ts
@@ -52,6 +52,7 @@ export { UIError } from './error/uiError'
 export { UINotFoundError } from './error/uiNotFoundError'
 
 export type { KnownKeyOf } from './utilTypes/knownKeyOf'
+export type { Writable, PartialWritable } from './utilTypes/writeable'
 
 export type { CVEventMap, CVEventType, CVMainEventMap, CVTitleEventMap } from './event/events'
 

--- a/churaverse-engine-client/src/utilTypes/writeable.ts
+++ b/churaverse-engine-client/src/utilTypes/writeable.ts
@@ -1,0 +1,29 @@
+/**
+ * 全てのプロパティからreadonlyを外すMapped Type
+ *
+ * @example
+ * interface ReadonlyType {
+ * readonly a: string
+ * readonly b: number
+ * }
+ *
+ * // WritableType = { a: string; b: number; }
+ * type WritableType = Writable<ReadonlyType>
+ */
+export type Writable<T> = {
+  -readonly [P in keyof T]: T[P]
+}
+
+/**
+ * 型Tのプロパティのうち、指定したキーKのみreadonlyを外すユーティリティ型
+ *
+ * @example
+ * interface ReadonlyType {
+ * readonly a: string
+ * readonly b: number
+ * }
+ *
+ * // WritableA = { a: string; readonly b: number; }
+ * type WritableA = PartialWritable<ReadonlyType, 'a'>
+ */
+export type PartialWritable<T, K extends keyof T> = Omit<T, K> & Writable<Pick<T, K>>

--- a/churaverse-engine-server/src/index.ts
+++ b/churaverse-engine-server/src/index.ts
@@ -34,6 +34,7 @@ export { CVError } from './error/cvError'
 export { SceneUndefinedError } from './error/sceneUndefinedError'
 
 export type { KnownKeyOf } from './utilTypes/knownKeyOf'
+export type { Writable, PartialWritable } from './utilTypes/writeable'
 
 export type { CVEventMap, CVEventType, CVMainEventMap, CVTitleEventMap } from './event/events'
 

--- a/churaverse-engine-server/src/utilTypes/writeable.ts
+++ b/churaverse-engine-server/src/utilTypes/writeable.ts
@@ -1,0 +1,29 @@
+/**
+ * 全てのプロパティからreadonlyを外すMapped Type
+ *
+ * @example
+ * interface ReadonlyType {
+ * readonly a: string
+ * readonly b: number
+ * }
+ *
+ * // WritableType = { a: string; b: number; }
+ * type WritableType = Writable<ReadonlyType>
+ */
+export type Writable<T> = {
+  -readonly [P in keyof T]: T[P]
+}
+
+/**
+ * 型Tのプロパティのうち、指定したキーKのみreadonlyを外すユーティリティ型
+ *
+ * @example
+ * interface ReadonlyType {
+ * readonly a: string
+ * readonly b: number
+ * }
+ *
+ * // WritableA = { a: string; readonly b: number; }
+ * type WritableA = PartialWritable<ReadonlyType, 'a'>
+ */
+export type PartialWritable<T, K extends keyof T> = Omit<T, K> & Writable<Pick<T, K>>


### PR DESCRIPTION
再接続の実装において、readonlyのプロパティを上書きの必要が出てきたため、readonlyを外すユーティリティ型の実装を行なった。

チケットへのリンク：https://churadata.backlog.com/view/CV-806