### PR TITLE
webRTC周りの機能実装

### DIFF
--- a/churaverse-engine-client/src/event/gamePhase/init.ts
+++ b/churaverse-engine-client/src/event/gamePhase/init.ts
@@ -14,4 +14,7 @@ declare module '../events' {
   export interface CVMainEventMap {
     init: InitEvent
   }
+  export interface CVMeetingEventMap {
+    init: InitEvent
+  }
 }

--- a/churaverse-engine-server/src/event/backendPhase/init.ts
+++ b/churaverse-engine-server/src/event/backendPhase/init.ts
@@ -16,4 +16,7 @@ declare module '../events' {
   export interface CVMainEventMap {
     init: InitEvent
   }
+  export interface CVMeetingEventMap {
+    init: InitEvent
+  }
 }

--- a/churaverse-engine-server/src/event/backendPhase/start.ts
+++ b/churaverse-engine-server/src/event/backendPhase/start.ts
@@ -14,4 +14,7 @@ declare module '../events' {
   export interface CVMainEventMap {
     start: StartEvent
   }
+  export interface CVMeetingEventMap {
+    start: StartEvent
+  }
 }

--- a/churaverse-engine-server/src/event/backendPhase/update.ts
+++ b/churaverse-engine-server/src/event/backendPhase/update.ts
@@ -14,4 +14,7 @@ declare module '../events' {
   export interface CVMainEventMap {
     update: UpdateEvent
   }
+  export interface CVMeetingEventMap {
+    update: UpdateEvent
+  }
 }


### PR DESCRIPTION
# 概要
チケット：https://churadata.backlog.com/view/CV-874
`feature/CV-858/add-meeting-scene` で追加した MeetingScene（会議モード）に、会議用 WebRTC と UI を追加する PR です。  
MeetingScene 専用プラグイン（MeetingCoreUiPlugin / MeetingWebRtcPlugin）の実装と、既存プラグインの MeetingScene 対応（型拡張）を行っています。

## 変更内容

### 新規プラグイン（churaverse-plugins / meetingPlugins）

- **MeetingCoreUiPlugin**  
  - 会議画面の UI：ビデオグリッド・コントロールバー（マイク/カメラ/画面共有/退出）・サイドバー（参加者一覧・チャットタブ）
- **MeetingWebRtcPlugin**  
  - LiveKit 接続、マイク/カメラ/画面共有の ON/OFF、参加者タイルの動的表示、退出処理  
  - 既存の MainScene 用 WebRtcPlugin は IMainScene 専用のため、MeetingScene 用に新規実装（livekit-client を直接利用）

### 既存プラグインの MeetingScene 対応（型拡張のみ）

- **クライアント**: NetworkPlugin / TransitionPlugin の `StoreInMeeting` 拡張、`CVMeetingEventMap` に `willSceneTransition` 追加
- **サーバー**: NetworkPlugin / TextChatPlugin / KickPlugin の `MeetingMessageMap` 等を拡張し、MeetingScene でメッセージ・イベントを扱えるように対応

## 注意点
このPRは、以下の2つのリポジトリのPRと同時にテスト、レビュー、マージをお願いします。
- https://github.com/churadata/churaverse_private/pull/407
- https://github.com/churadata/churaverse-plugins/pull/109

